### PR TITLE
Added a Plank Preferences Desktop Entry

### DIFF
--- a/plank/data/menulibre-plank-preferences.desktop
+++ b/plank/data/menulibre-plank-preferences.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.1
+Type=Application
+Name=Plank Preferences
+Comment=Edit Plank Preferences
+Icon=applications-other
+Exec=plank --preferences
+Actions=
+Categories=DesktopSettings;Settings;X-XFCE;X-Xfce-Toplevel;
+Keywords=plank;plank preferences;preferences;


### PR DESCRIPTION
There are currently Plank settings in the desktop category in the settings app, but this desktop entry runs "plank --preferences" to show all of Plank's settings. It also shows in the settings app.