### PR TITLE
fix: allow kbd navigation with 2 users

### DIFF
--- a/greeter/src/PantheonGreeter.vala
+++ b/greeter/src/PantheonGreeter.vala
@@ -389,12 +389,12 @@ public class PantheonGreeter : Gtk.Window {
                 settings.set_boolean ("greeter", "activate-numlock", !activate_numlock);
                 break;
             case Gdk.Key.Left:
-                if (userlist.size > 2) {
+                if (userlist.size > 1) {
                     userlist.select_prev_user ();
                 }
                 break;
             case Gdk.Key.Right:
-                if (userlist.size > 2) {
+                if (userlist.size > 1) {
                     userlist.select_next_user ();
                 }
                 break;


### PR DESCRIPTION
I'm not sure this commit makes any sense, but I've noticed that with only 2 users (`userlist.size == 2`, I guess?) I can't use left and right arrows to select a user to log in. I'm hoping this changes that but it's untested....